### PR TITLE
fix: ダッシュボードのUI崩れを修正

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -69,9 +69,9 @@ export default function DashboardPage() {
       <Sidebar />
 
       {/* メインコンテンツエリア */}
-      <div className="lg:pl-64">
+      <div className="lg:ml-64">
         {/* トップヘッダー */}
-        <header className="bg-white shadow-sm border-b border-gray-200">
+        <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-10">
           <div className="flex items-center justify-between h-16 px-4 sm:px-6 lg:px-8">
             <div className="flex items-center">
               {/* モバイル用メニューボタン */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -71,7 +71,8 @@ const Sidebar = ({ className }: SidebarProps) => {
       {/* サイドバー */}
       <div
         className={cn(
-          'fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0',
+          'fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 transition-transform duration-300 ease-in-out',
+          'lg:translate-x-0',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full',
           className
         )}


### PR DESCRIPTION
管理者ログイン後のダッシュボード画面のUI崩れ（ヘッダーの位置）を修正しました

<img width="1268" height="937" alt="image" src="https://github.com/user-attachments/assets/79489027-7abe-4d76-a83c-392c3d7dc60f" />
