### PR TITLE
fix: ルートパスで404を返すように変更

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
-import { redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 
 /**
  * ルートページ
- * デフォルトで顧客向けメニューページにリダイレクト
+ * 404を返す
  */
 export default function Home() {
-  redirect('/menu');
+  notFound();
 }


### PR DESCRIPTION
## Summary
- ルートパス(`/`)にアクセスした際に、`/menu`へのリダイレクトではなく404ページを表示するように変更
店舗側機能は/login
顧客側機能は/menu
にアクセスしてください

## Changes
- `src/app/page.tsx`: `redirect('/menu')` を `notFound()` に変更

## Reason
- 意図しないルート以外のパスが `/menu` にリダイレクトされる問題を防ぐため
- ルートパスは使用しないため、404を返すことで明示的に無効化

## Test plan
- [ ] ルートパス(`/`)にアクセスして404ページが表示されることを確認
- [ ] `/menu` に直接アクセスして正常に表示されることを確認
- [ ] `/login`, `/dashboard` などの既存のルートが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)