### PR TITLE
feat: 注文管理用のordersとorder_itemsテーブルを追加

### DIFF
--- a/prisma/migrations/20251102020810_add_order_tables/migration.sql
+++ b/prisma/migrations/20251102020810_add_order_tables/migration.sql
@@ -1,0 +1,63 @@
+-- CreateEnum
+CREATE TYPE "public"."OrderStatus" AS ENUM ('pending', 'confirmed', 'preparing', 'ready', 'completed', 'cancelled');
+
+-- CreateEnum
+CREATE TYPE "public"."PaymentStatus" AS ENUM ('pending', 'paid');
+
+-- CreateTable
+CREATE TABLE "public"."orders" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "order_number" VARCHAR(50) NOT NULL,
+    "customer_id" UUID NOT NULL,
+    "status" "public"."OrderStatus" NOT NULL,
+    "total_amount" INTEGER NOT NULL,
+    "payment_status" "public"."PaymentStatus" NOT NULL DEFAULT 'pending',
+    "payment_method" VARCHAR(50),
+    "notes" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMPTZ,
+
+    CONSTRAINT "orders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."order_items" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "order_id" UUID NOT NULL,
+    "product_id" UUID NOT NULL,
+    "product_name" VARCHAR(255) NOT NULL,
+    "product_price" INTEGER NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "subtotal" INTEGER NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "order_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "orders_order_number_key" ON "public"."orders"("order_number");
+
+-- CreateIndex
+CREATE INDEX "idx_orders_customer_id" ON "public"."orders"("customer_id");
+
+-- CreateIndex
+CREATE INDEX "idx_orders_status" ON "public"."orders"("status");
+
+-- CreateIndex
+CREATE INDEX "idx_orders_created_at" ON "public"."orders"("created_at");
+
+-- CreateIndex
+CREATE INDEX "idx_order_items_order_id" ON "public"."order_items"("order_id");
+
+-- CreateIndex
+CREATE INDEX "idx_order_items_product_id" ON "public"."order_items"("product_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "public"."customers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."order_items" ADD CONSTRAINT "order_items_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "public"."orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."order_items" ADD CONSTRAINT "order_items_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,21 @@ generator client {
   provider = "prisma-client-js"
 }
 
+// Enums for order management
+enum OrderStatus {
+  pending
+  confirmed
+  preparing
+  ready
+  completed
+  cancelled
+}
+
+enum PaymentStatus {
+  pending
+  paid
+}
+
 // 環境別のデータベース接続設定
 datasource db {
   provider  = "postgresql"
@@ -30,16 +45,17 @@ model User {
 
 // Products table - for product listing functionality
 model Product {
-  id          String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name        String     @db.VarChar(255)
-  description String?    @db.Text
-  price       Int        // 価格は円単位で保存
-  imageUrl    String?    @map("image_url") @db.Text
-  category    String?    @db.VarChar(100)
-  isActive    Boolean    @default(true) @map("is_active")
-  createdAt   DateTime   @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime   @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  id          String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name        String      @db.VarChar(255)
+  description String?     @db.Text
+  price       Int         // 価格は円単位で保存
+  imageUrl    String?     @map("image_url") @db.Text
+  category    String?     @db.VarChar(100)
+  isActive    Boolean     @default(true) @map("is_active")
+  createdAt   DateTime    @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   cartItems   CartItem[]
+  orderItems  OrderItem[]
 
   @@index([category], map: "idx_products_category")
   @@index([isActive], map: "idx_products_is_active")
@@ -58,6 +74,7 @@ model Customer {
   updatedAt    DateTime   @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   lastLoginAt  DateTime?  @map("last_login_at") @db.Timestamptz
   cartItems    CartItem[]
+  orders       Order[]
 
   @@index([lineUserId], map: "idx_customers_line_user_id")
   @@map("customers")
@@ -79,4 +96,46 @@ model CartItem {
   @@index([customerId], map: "idx_cart_items_customer_id")
   @@index([productId], map: "idx_cart_items_product_id")
   @@map("cart_items")
+}
+
+// Orders table - for order management
+model Order {
+  id            String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  orderNumber   String        @unique @map("order_number") @db.VarChar(50)
+  customerId    String        @map("customer_id") @db.Uuid
+  status        OrderStatus
+  totalAmount   Int           @map("total_amount") // 合計金額（円単位）
+  paymentStatus PaymentStatus @default(pending) @map("payment_status")
+  paymentMethod String?       @map("payment_method") @db.VarChar(50)
+  notes         String?       @db.Text
+  createdAt     DateTime      @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt     DateTime      @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  completedAt   DateTime?     @map("completed_at") @db.Timestamptz
+
+  customer   Customer    @relation(fields: [customerId], references: [id], onDelete: Restrict)
+  orderItems OrderItem[]
+
+  @@index([customerId], map: "idx_orders_customer_id")
+  @@index([status], map: "idx_orders_status")
+  @@index([createdAt], map: "idx_orders_created_at")
+  @@map("orders")
+}
+
+// Order items table - for order item details
+model OrderItem {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  orderId      String   @map("order_id") @db.Uuid
+  productId    String   @map("product_id") @db.Uuid
+  productName  String   @map("product_name") @db.VarChar(255) // 商品名のスナップショット
+  productPrice Int      @map("product_price") // 価格のスナップショット（円単位）
+  quantity     Int      @default(1)
+  subtotal     Int // 小計（円単位）
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  order   Order   @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  product Product @relation(fields: [productId], references: [id], onDelete: Restrict)
+
+  @@index([orderId], map: "idx_order_items_order_id")
+  @@index([productId], map: "idx_order_items_product_id")
+  @@map("order_items")
 }


### PR DESCRIPTION
## 概要
注文管理機能のためのデータベーススキーマを追加します。

## 変更内容

### 追加テーブル

#### ordersテーブル
- 注文全体の情報を管理
- 注文番号（ユニーク）
- ステータス管理（pending, confirmed, preparing, ready, completed, cancelled）
- 決済ステータス（pending, paid）
- 合計金額
- 注文メモ

#### order_itemsテーブル
- 注文の商品明細を管理
- 商品名・価格のスナップショット（価格変更に対応）
- 数量と小計

### リレーション
- `orders` → `customers` (多対一)
- `orders` → `order_items` (一対多)
- `order_items` → `products` (多対一)
