### PR TITLE
refactor: カート数量0で注文確定時にアイテム削除

### DIFF
--- a/src/app/(customer)/cart/page.tsx
+++ b/src/app/(customer)/cart/page.tsx
@@ -123,7 +123,7 @@ export default function CartPage() {
                     index !== cartItems.length - 1
                       ? 'border-b border-gray-200'
                       : ''
-                  }`}
+                  } ${item.quantity === 0 ? 'opacity-50 bg-gray-50' : ''}`}
                 >
                   {/* 商品画像 */}
                   <div className="relative w-20 h-20 flex-shrink-0 bg-gray-200 rounded-md overflow-hidden">
@@ -162,8 +162,7 @@ export default function CartPage() {
                           onClick={() =>
                             handleUpdateQuantity(item.id, item.quantity - 1)
                           }
-                          className="w-8 h-8 flex items-center justify-center bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                          disabled={item.quantity <= 1}
+                          className="w-8 h-8 flex items-center justify-center bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors"
                           aria-label="数量を減らす"
                         >
                           -

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -1,0 +1,119 @@
+/**
+ * カート状態を管理するZustandストア
+ * フロントエンドのみで数量変更を管理し、localStorageで永続化します
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+/**
+ * カートアイテムの型定義
+ */
+export type CartItem = {
+  id: string;
+  productId: string;
+  productName: string;
+  productDescription: string | null;
+  productImageUrl: string | null;
+  productCategory: string | null;
+  price: number;
+  quantity: number;
+  subtotal: number;
+};
+
+/**
+ * カート状態のインターフェース
+ */
+interface CartState {
+  items: CartItem[];
+  loading: boolean;
+}
+
+/**
+ * カート操作のアクション
+ */
+interface CartActions {
+  setItems: (items: CartItem[]) => void;
+  updateQuantity: (itemId: string, quantity: number) => void;
+  removeItem: (itemId: string) => void;
+  clearCart: () => void;
+  setLoading: (loading: boolean) => void;
+  getItemCount: () => number;
+  getTotalAmount: () => number;
+}
+
+/**
+ * カート状態管理用のZustandストア
+ * - フロントエンドのみで数量変更を管理
+ * - localStorageで永続化
+ * - 注文確定時にサーバーへ一括送信（別PRで実装予定）
+ */
+export const useCartStore = create<CartState & CartActions>()(
+  persist(
+    (set, get) => ({
+      // ===== 初期状態 =====
+      items: [],
+      loading: false,
+
+      // ===== アクション =====
+
+      /**
+       * カートアイテムを一括設定（サーバーから取得した初期データ用）
+       */
+      setItems: (items) => set({ items }),
+
+      /**
+       * カートアイテムの数量を更新
+       * - 数量0も許可（削除予約状態）
+       * - 注文確定時に数量0のアイテムをサーバーで削除
+       * - サーバーには送信せず、フロントのみで管理
+       */
+      updateQuantity: (itemId, quantity) =>
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.id === itemId
+              ? {
+                  ...item,
+                  quantity: Math.max(0, quantity),
+                  subtotal: item.price * Math.max(0, quantity),
+                }
+              : item
+          ),
+        })),
+
+      /**
+       * カートアイテムを削除
+       */
+      removeItem: (itemId) =>
+        set((state) => ({
+          items: state.items.filter((item) => item.id !== itemId),
+        })),
+
+      /**
+       * カートを空にする
+       */
+      clearCart: () => set({ items: [] }),
+
+      /**
+       * ローディング状態を設定
+       */
+      setLoading: (loading) => set({ loading }),
+
+      /**
+       * カート内のアイテム数を取得
+       */
+      getItemCount: () => get().items.length,
+
+      /**
+       * カート内の合計金額を計算
+       */
+      getTotalAmount: () =>
+        get().items.reduce((sum, item) => sum + item.subtotal, 0),
+    }),
+    {
+      name: 'cart-storage',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ items: state.items }),
+    }
+  )
+);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,2 +1,4 @@
 export { useUserStore } from './userStore';
 export { useAppStore } from './appStore';
+export { useCartStore } from './cartStore';
+export type { CartItem } from './cartStore';


### PR DESCRIPTION
### 概要
以下の変更を実装しました

・カート数量を1から0に変更可能にし、削除予約状態として保持
・削除予定のアイテムは注文確定時（今後実装予定）に削除される
・カート数量をフロントエンド管理にし、数量変更時のサーバーリクエストを削除して負荷を軽減



https://github.com/user-attachments/assets/57a43691-22a7-4eb3-8e48-bc189af536d5

