### PR TITLE
add: PR作成者を自動でアサインに追加するワークフローを追加

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,23 @@
+name: Auto Assign PR
+
+# PRが作成されたときに自動的に作成者をassigneesに追加
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign PR to creator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.pull_request.user.login]
+            });


### PR DESCRIPTION
以下画像の箇所に自動的にPR作成者をアサインするためのワークフローを追加しました

<img width="335" height="90" alt="image" src="https://github.com/user-attachments/assets/a19b6541-0e95-45d3-9c7c-2ee43d206516" />
