### PR TITLE
refactor: カートの冗長なエラーモーダルを削除

### DIFF
--- a/src/app/(customer)/cart/page.tsx
+++ b/src/app/(customer)/cart/page.tsx
@@ -49,16 +49,6 @@ export default function CartPage() {
 
   // 注文確定ハンドラー
   const handleCheckout = async () => {
-    if (!hasOrderableItems) {
-      setModal({
-        isOpen: true,
-        type: 'error',
-        title: 'エラー',
-        message: '注文可能な商品がありません',
-      });
-      return;
-    }
-
     setIsOrdering(true);
 
     try {


### PR DESCRIPTION
概要
以下の内容を修正しました

カートページでアイテムがない（数量０）時に、注文確定ボタンを押すと表示されていたエラーモーダルを削除して、ボタン無効化するよう変更しました


https://github.com/user-attachments/assets/c2193721-d2fd-4e94-ab68-2b37937731eb

